### PR TITLE
Make session uri mandatory, remove optional length

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -576,8 +576,7 @@ MOQTClientSetupMessage = {
 MOQTGoaway = {
   type: "goaway"
   ? length: uint64
-  ? new_session_uri_length: RawInfo
-  ? new_session_uri: RawInfo
+  new_session_uri: RawInfo
 }
 ~~~
 {: #goaway-def title="MOQTGoaway definition"}


### PR DESCRIPTION
This is the same as, e.g., reason_phrase in the error messages.