### PR TITLE
Make object datagram created payload optional

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -246,7 +246,7 @@ MOQTObjectDatagramCreated = {
     publisher_priority: uint8
     extension_headers_length: uint64
     ? extension_headers: [* MOQTExtensionHeader]
-    object_payload: RawInfo
+    ? object_payload: RawInfo
 
     * $$moqt-objectdatagramcreated-extension
 }


### PR DESCRIPTION
It is already mandatory for the object datagram created event and since status datagrams now have their own type, there should always be a payload.