### PR TITLE
Add MOQTByteString type for track/track namespace and define track_namespace fields

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -614,15 +614,24 @@ MOQTUnknownParameter = {
 ~~~
 {: #moqtunknownparameter-def title="MOQTUnknownParameter definition"}
 
-## MOQTStringOrBytes
+## MOQTByteString
+
+The MOQTByteString type allows representing MOQT bytestrings, such as the value
+of a Track or Track Namespace tuple field, using two different encodings. The
+`value` field can be used for bytestrings that can be encoded in UTF-8. The
+`value_bytes` field can be used for bytestrings of any type by using the
+`hexstring` encoding.
+
+Implementations SHOULD populate one of either the `value` or `value_bytes`
+field. Populating both fields is redundant.
 
 ~~~ cddl
-MOQTStringOrBytes = {
+MOQTByteString = {
   ? value: text
   ? value_bytes: hexstring
 }
 ~~~
-{: #moqtstringorbytes-def title="MOQTStringOrBytes definition"}
+{: #MOQTByteString-def title="MOQTByteString definition"}
 
 ## MOQTControlMessage
 
@@ -714,8 +723,8 @@ MOQTSubscribe = {
   type: "subscribe"
   subscribe_id: uint64
   track_alias: uint64
-  track_namespace: [ *MOQTStringOrBytes]
-  track_name: MOQTStringOrBytes
+  track_namespace: [ *MOQTByteString]
+  track_name: MOQTByteString
   subscriber_priority: uint8
   group_order: uint8
   filter_type: uint64
@@ -764,8 +773,8 @@ MOQTFetch = {
   group_order: uint8
   fetch_type: uint64
 
-  track_namespace: [ *MOQTStringOrBytes]
-  ? track_name: MOQTStringOrBytes
+  track_namespace: [ *MOQTByteString]
+  ? track_name: MOQTByteString
   ? start_group: uint64
   ? start_object: uint64
   ? end_group: uint64
@@ -796,7 +805,7 @@ MOQTFetchCancel = {
 ~~~ cddl
 MOQTAnnounceOk = {
   type: "announce_ok"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
 }
 ~~~
 {: #announceok-def title="MOQTAnnounceOk definition"}
@@ -806,7 +815,7 @@ MOQTAnnounceOk = {
 ~~~ cddl
 MOQTAnnounceError = {
   type: "announce_error"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
   error_code: uint64
   ? reason: text
   ? reason_bytes: hexstring
@@ -819,7 +828,7 @@ MOQTAnnounceError = {
 ~~~ cddl
 MOQTAnnounceCancel = {
   type: "announce_cancel"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
   error_code: uint64
   ? reason: text
   ? reason_bytes: hexstring
@@ -832,8 +841,8 @@ MOQTAnnounceCancel = {
 ~~~ cddl
 MOQTTrackStatusRequest = {
   type: "track_status_request"
-  track_namespace: [ *MOQTStringOrBytes]
-  track_name: MOQTStringOrBytes
+  track_namespace: [ *MOQTByteString]
+  track_name: MOQTByteString
 }
 ~~~
 {: #trackstatusrequest-def title="MOQTTrackStatusRequest definition"}
@@ -843,7 +852,7 @@ MOQTTrackStatusRequest = {
 ~~~ cddl
 MOQTSubscribeAnnounces = {
   type: "subscribe_announces"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
   number_of_parameters: uint64
   subscribe_parameters: [* $MOQTParameter]
 }
@@ -855,7 +864,7 @@ MOQTSubscribeAnnounces = {
 ~~~ cddl
 MOQTUnsubscribeAnnounces = {
   type: "subscribe_announces"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
 }
 ~~~
 {: #unsubscribeannounces-def title="MOQTUnsubscribeAnnounces definition"}
@@ -959,7 +968,7 @@ MOQTSubscribesBlocked = {
 ~~~ cddl
 MOQTAnnounce = {
   type: "announce"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
   number_of_parameters: uint64
   subscribe_parameters: [* $MOQTParameter]
 }
@@ -971,7 +980,7 @@ MOQTAnnounce = {
 ~~~ cddl
 MOQTUnannounce = {
   type: "unannounce"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
 }
 ~~~
 {: #unannounce-def title="MOQTAnnounce definition"}
@@ -981,8 +990,8 @@ MOQTUnannounce = {
 ~~~ cddl
 MOQTTrackStatus = {
   type: "track_status"
-  track_namespace: [ *MOQTStringOrBytes]
-  track_name: MOQTStringOrBytes
+  track_namespace: [ *MOQTByteString]
+  track_name: MOQTByteString
   status_code: uint64
   last_group_id: uint64
   last_object_id: uint64
@@ -996,7 +1005,7 @@ MOQTTrackStatus = {
 ~~~ cddl
 MOQTSubscribeAnnouncesOk = {
   type: "subscribe_announces_ok"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
 }
 ~~~
 {: #subscribeannouncesok  -def title="MOQTSubscribeAnnouncesOk definition"}
@@ -1006,7 +1015,7 @@ MOQTSubscribeAnnouncesOk = {
 ~~~ cddl
 MOQTSubscribeAnnouncesError = {
   type: "subscribe_announces_error"
-  track_namespace: [ *MOQTStringOrBytes]
+  track_namespace: [ *MOQTByteString]
   error_code: uint64
   ? reason: text
   ? reason_bytes: hexstring

--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -614,6 +614,16 @@ MOQTUnknownParameter = {
 ~~~
 {: #moqtunknownparameter-def title="MOQTUnknownParameter definition"}
 
+## MOQTStringOrBytes
+
+~~~ cddl
+MOQTStringOrBytes = {
+  ? value: text
+  ? value_bytes: hexstring
+}
+~~~
+{: #moqtstringorbytes-def title="MOQTStringOrBytes definition"}
+
 ## MOQTControlMessage
 
 The generic `$MOQTControlMessage` is defined here as a CDDL "type socket" extension point.
@@ -704,8 +714,8 @@ MOQTSubscribe = {
   type: "subscribe"
   subscribe_id: uint64
   track_alias: uint64
-  ; track_namespace: TODO pending tuple decision
-  track_name: RawInfo
+  track_namespace: [ *MOQTStringOrBytes]
+  track_name: MOQTStringOrBytes
   subscriber_priority: uint8
   group_order: uint8
   filter_type: uint64
@@ -754,8 +764,8 @@ MOQTFetch = {
   group_order: uint8
   fetch_type: uint64
 
-  ; ? track_namespace: TODO pending tuple decision
-  ? track_name: RawInfo
+  track_namespace: [ *MOQTStringOrBytes]
+  ? track_name: MOQTStringOrBytes
   ? start_group: uint64
   ? start_object: uint64
   ? end_group: uint64
@@ -786,7 +796,7 @@ MOQTFetchCancel = {
 ~~~ cddl
 MOQTAnnounceOk = {
   type: "announce_ok"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
 }
 ~~~
 {: #announceok-def title="MOQTAnnounceOk definition"}
@@ -796,7 +806,7 @@ MOQTAnnounceOk = {
 ~~~ cddl
 MOQTAnnounceError = {
   type: "announce_error"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
   error_code: uint64
   ? reason: text
   ? reason_bytes: hexstring
@@ -809,7 +819,7 @@ MOQTAnnounceError = {
 ~~~ cddl
 MOQTAnnounceCancel = {
   type: "announce_cancel"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
   error_code: uint64
   ? reason: text
   ? reason_bytes: hexstring
@@ -822,8 +832,8 @@ MOQTAnnounceCancel = {
 ~~~ cddl
 MOQTTrackStatusRequest = {
   type: "track_status_request"
-  ; track_namespace: TODO pending tuple decision
-  track_name: RawInfo
+  track_namespace: [ *MOQTStringOrBytes]
+  track_name: MOQTStringOrBytes
 }
 ~~~
 {: #trackstatusrequest-def title="MOQTTrackStatusRequest definition"}
@@ -833,7 +843,7 @@ MOQTTrackStatusRequest = {
 ~~~ cddl
 MOQTSubscribeAnnounces = {
   type: "subscribe_announces"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
   number_of_parameters: uint64
   subscribe_parameters: [* $MOQTParameter]
 }
@@ -845,7 +855,7 @@ MOQTSubscribeAnnounces = {
 ~~~ cddl
 MOQTUnsubscribeAnnounces = {
   type: "subscribe_announces"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
 }
 ~~~
 {: #unsubscribeannounces-def title="MOQTUnsubscribeAnnounces definition"}
@@ -949,7 +959,7 @@ MOQTSubscribesBlocked = {
 ~~~ cddl
 MOQTAnnounce = {
   type: "announce"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
   number_of_parameters: uint64
   subscribe_parameters: [* $MOQTParameter]
 }
@@ -961,7 +971,7 @@ MOQTAnnounce = {
 ~~~ cddl
 MOQTUnannounce = {
   type: "unannounce"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
 }
 ~~~
 {: #unannounce-def title="MOQTAnnounce definition"}
@@ -971,8 +981,8 @@ MOQTUnannounce = {
 ~~~ cddl
 MOQTTrackStatus = {
   type: "track_status"
-  ; track_namespace: TODO pending tuple decision
-  track_name: RawInfo
+  track_namespace: [ *MOQTStringOrBytes]
+  track_name: MOQTStringOrBytes
   status_code: uint64
   last_group_id: uint64
   last_object_id: uint64
@@ -986,7 +996,7 @@ MOQTTrackStatus = {
 ~~~ cddl
 MOQTSubscribeAnnouncesOk = {
   type: "subscribe_announces_ok"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
 }
 ~~~
 {: #subscribeannouncesok  -def title="MOQTSubscribeAnnouncesOk definition"}
@@ -996,7 +1006,7 @@ MOQTSubscribeAnnouncesOk = {
 ~~~ cddl
 MOQTSubscribeAnnouncesError = {
   type: "subscribe_announces_error"
-  ; track_namespace: TODO pending tuple decision
+  track_namespace: [ *MOQTStringOrBytes]
   error_code: uint64
   ? reason: text
   ? reason_bytes: hexstring


### PR DESCRIPTION
…_namespace fields

A proposal to close https://github.com/LPardue/draft-pardue-moq-qlog-moq-events/issues/14

The difficulty with MOQT is it allows these track things to be "bytes", which may or may not be safely encoded as regular strings. Previously, I proposed RawInfo for track_name fields. @mengelbart provided an example log line and I don't think its very ergonomic

```
{"time":0.962961,"name":"moqt:control_message_created","data":{"stream_id":0,"length":22,"message":{"type":"subscribe","subscribe_id":0,"track_alias":0,"track_namespace":["clock"],"track_name":{"length":6,"payload_length":6,"data":"7365636f6e64"},"subscriber_priority":0,"group_order":0,"filter_type":0,"number_of_parameters":0}}}
```

The raw info's `"data":"7365636f6e64"` is a hexstring encoding of the value `second`. If the log producer is happy to encode as a string, it can. If its not happy to, it can use hexstring. Using rawinfo doesn't seem to add much value here unless you wanted to omit the actual value and just record the length, but I really don't see that being useful in MOQ.

So instead, with this proposal a log line would include

```
"track_name": {"value": "second"}
```

that's still verbose but then allows someone sending binary track names to so something like 

```
"track_name": {"value_bytes": "<hex-encoded binary thing>"}
```

This then extends to the track_namespace field, which could be something like

```
"track_namespace": [{"value_bytes": "<hex-encoded binary thing>"}, {"value": "second"}]
```