### PR TITLE
[updates for draft-14] Remove track alias from MOQTSubscribeError

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -805,7 +805,6 @@ MOQTSubscribeError = {
   error_code: uint64
   ? reason: text
   ? reason_bytes: hexstring
-  track_alias: uint64
 }
 ~~~
 {: #subscribeerror-def title="MOQTSubscribeError definition"}


### PR DESCRIPTION
In draft-14 of the specification, SUBSCRIBE_ERROR does not carry a track alias.