### PR TITLE
[updates for draft-14] Remove object_datagram_status* and modify object_datagram*

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -250,8 +250,8 @@ MOQTObjectDatagramCreated = {
     publisher_priority: uint8
     ? extension_headers_length: uint64
     ? extension_headers: [* MOQTExtensionHeader]
-    ? object_payload: RawInfo
     ? object_status: uint64
+    ? object_payload: RawInfo
     end_of_group: bool
 
     * $$moqt-objectdatagramcreated-extension
@@ -272,8 +272,8 @@ MOQTObjectDatagramParsed = {
     publisher_priority: uint8
     ? extension_headers_length: uint64
     ? extension_headers: [* MOQTExtensionHeader]
-    ? object_payload: RawInfo
     ? object_status: uint64
+    ? object_payload: RawInfo
     end_of_group: bool
 
     * $$moqt-objectdatagramparsed-extension


### PR DESCRIPTION
In draft-14, we don't have a separate "OBJECT_DATAGRAM_STATUS". I'm making modifications to the mLog specification in order to be more in-line with the MoQ specification. Here are the changes made:

- Remove object_datagram_status_created and object_datagram_status_parsed
- Make object_id an optional field of MOQTObjectDatagramParsed and MOQTObjectDatagramCreated
- Add object_status as an optional field of MOQTObjectDatagramParsed and MOQTObjectDatagramCreated
- Add a bool "end_of_group" field to MOQTObjectDatagramParsed and MOQTObjectDatagramCreated
- Make extension_headers_length an optional field of MOQTObjectDatagramParsed and MOQTObjectDatagramCreated