### PR TITLE
[updates for draft-14] Add setup parameters

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -491,7 +491,7 @@ MOQTAuthoritySetupParameter = {
 ~~~ cddl
 MOQTAuthorizationTokenSetupParameter = {
   name: "authorization_token"
-  alias_type: MOQTAliasType
+  alias_type: $MOQTAliasType
   ? token_alias: uint64
   ? token_type: uint64
   ? token_value: RawInfo


### PR DESCRIPTION
This commit adds the following setup parameters to the mLog definitions, in order to ensure that we're up-to-date with draft-14 of the MoQ specification:
* MOQTAuthoritySetupParameter
* MOQTMaxAuthTokenCacheSizeSetupParameter
* MOQTImplementationSetupParameter
* MOQTAuthorizationTokenSetupParameter