### PR TITLE
[updates for draft-15] Update MOQTClientSetupMessage and MOQTServerSetupMessage

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -733,8 +733,6 @@ $MOQTControlMessage /= MOQTBaseControlMessages
 ~~~ cddl
 MOQTClientSetupMessage = {
   type: "client_setup"
-  number_of_supported_versions: uint64
-  supported_versions: [* uint64]
   number_of_parameters: uint64
   ? setup_parameters: [* $MOQTSetupParameter]
 }
@@ -746,7 +744,6 @@ MOQTClientSetupMessage = {
 ~~~ cddl
 MOQTServerSetupMessage = {
   type: "server_setup"
-  selected_version: uint64
   number_of_parameters: uint64
   ? setup_parameters: [* $MOQTSetupParameter]
 }


### PR DESCRIPTION
Changes made to MOQTClientSetupMessage:
* Remove fields no longer used in version 15: supported_versions, number_of_supported versions.

Changes made to MOQTServerSetupMessage:
* Remove fields no longer used in version 15: selected_version