### PR TITLE
[updates for draft-15] Update MOQTFetchOk to remove parameterized field

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -1041,7 +1041,6 @@ $MOQTFetchType /=  "standalone" /
 MOQTFetchOk = {
   type: "fetch_ok"
   request_id: uint64
-  group_order: uint8
   end_of_track: uint8
   end_location: MOQTLocation
   number_of_parameters: uint64


### PR DESCRIPTION
group_order is now present in the parameters, so I'm removing that field in the MOQTFetchOk structure.