### PR TITLE
[updates for draft-15] Remove retry_interval from MOQTRequestError

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -905,7 +905,6 @@ MOQTRequestError = {
   type: "request_error"
   request_id: uint64
   error_code: uint64
-  retry_interval: uint64
   ? reason: text
   ? reason_bytes: hexstring
 }


### PR DESCRIPTION
I had accidentally added retry_interval into the MOQTRequestError structure, because it is present in draft 16, but not draft 15.

I'll add it in later on when we update the mLog specification to be in line with draft 16.