### PR TITLE
[updates for draft-15] Make publisher_priority optional in MOQTObjectDatagramCreated

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -247,7 +247,7 @@ MOQTObjectDatagramCreated = {
     track_alias: uint64
     group_id: uint64
     ? object_id: uint64
-    publisher_priority: uint8
+    ? publisher_priority: uint8
     ? extension_headers_length: uint64
     ? extension_headers: [* MOQTExtensionHeader]
     ? object_status: uint64


### PR DESCRIPTION
This makes it in line with the MoQ specification.