### PR TITLE
Some small fixes

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -860,7 +860,6 @@ MOQTServerSetupMessage = {
 ~~~ cddl
 MOQTGoaway = {
   type: "goaway"
-  ? length: uint64
   new_session_uri: RawInfo
 }
 ~~~


### PR DESCRIPTION
I reordered the setup parameters and the publish control messages to match the order in the MoQT draft.

I also removed the length field from the goaway message. I think this was an oversight a long time ago.