### PR TITLE
[updates for draft-16] Update MOQTPublishNamespaceDone to be request id based

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -1102,7 +1102,7 @@ MOQTNamespace = {
 ~~~ cddl
 MOQTPublishNamespaceDone = {
   type: "publish_namespace_done"
-  track_namespace: [ *MOQTByteString]
+  request_id: uint64
 }
 ~~~
 {: #publishnamespacedone-def title="MOQTPublishNamespaceDone definition"}


### PR DESCRIPTION
In draft-16, we have the request_id rather than the track namespace in the MOQTPublishNamespaceDone message.