### PR TITLE
[updates for draft-16] Make extension_headers_length optional for MOQTFetchObjectCreated/Parsed

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -433,7 +433,7 @@ MOQTFetchObjectCreated = {
     ? subgroup_id: uint64
     ? object_id: uint64
     ? publisher_priority: uint8
-    extension_headers_length: uint64
+    ? extension_headers_length: uint64
     ? extension_headers: [* MOQTExtensionHeader]
     object_payload_length: uint64
     ? object_status: uint64
@@ -464,7 +464,7 @@ MOQTFetchObjectParsed = {
     ? subgroup_id: uint64
     ? object_id: uint64
     ? publisher_priority: uint8
-    extension_headers_length: uint64
+    ? extension_headers_length: uint64
     ? extension_headers: [* MOQTExtensionHeader]
     object_payload_length: uint64
     ? object_status: uint64


### PR DESCRIPTION
This field is only present when the EXTENSIONS flag (0x20) is set in the serialization flags.