### PR TITLE
[updates for draft-17] Remove "subscribe_namespace" from MOQTStreamType

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -233,8 +233,7 @@ MOQTStreamTypeSet = {
 
 $MOQTStreamType /=  "control" /
                     "subgroup_header" /
-                    "fetch_header" /
-                    "subscribe_namespace"
+                    "fetch_header"
 ~~~
 {: #streamtypeset-def title="MOQTStreamTypeSet definition"}
 


### PR DESCRIPTION
In draft-17, SUBSCRIBE_NAMESPACE is sent on a bidi stream. Also, the SETUP messages go over unidirectional streams.