### PR TITLE
[updates for draft-17] Remove obsolete control messages

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -821,19 +821,15 @@ MOQTBaseControlMessages = MOQTSetupMessage /
                           MOQTSubscribe /
                           MOQTSubscribeOk /
                           MOQTRequestUpdate /
-                          MOQTUnsubscribe /
                           MOQTPublish /
                           MOQTPublishOk /
                           MOQTPublishDone /
                           MOQTFetch /
                           MOQTFetchOk /
-                          MOQTFetchCancel /
                           MOQTTrackStatus /
                           MOQTPublishNamespace /
                           MOQTNamespace /
-                          MOQTPublishNamespaceDone /
                           MOQTNamespaceDone /
-                          MOQTPublishNamespaceCancel /
                           MOQTSubscribeNamespace /
                           MOQTPublishBlocked
 
@@ -931,16 +927,6 @@ MOQTRequestUpdate = {
 ~~~
 {: #requestupdate-def title="MOQTRequestUpdate definition"}
 
-### MOQTUnsubscribe
-
-~~~ cddl
-MOQTUnsubscribe = {
-  type: "unsubscribe"
-  request_id: uint64
-}
-~~~
-{: #unsubscribe-def title="MOQTUnsubscribe definition"}
-
 ### MOQTPublish
 
 ~~~ cddl
@@ -1031,16 +1017,6 @@ MOQTFetchOk = {
 ~~~
 {: #fetchok-def title="MOQTFetchOk definition"}
 
-### MOQTFetchCancel
-
-~~~ cddl
-MOQTFetchCancel = {
-  type: "fetch_cancel"
-  request_id: uint64
-}
-~~~
-{: #fetchcancel-def title="MOQTFetchCancel definition"}
-
 ### MOQTTrackStatus
 
 ~~~ cddl
@@ -1079,16 +1055,6 @@ MOQTNamespace = {
 ~~~
 {: #namespace-def title="MOQTNamespace definition"}
 
-### MOQTPublishNamespaceDone
-
-~~~ cddl
-MOQTPublishNamespaceDone = {
-  type: "publish_namespace_done"
-  request_id: uint64
-}
-~~~
-{: #publishnamespacedone-def title="MOQTPublishNamespaceDone definition"}
-
 ### MOQTNamespaceDone
 
 ~~~ cddl
@@ -1098,19 +1064,6 @@ MOQTNamespaceDone = {
 }
 ~~~
 {: #namespacedone-def title="MOQTNamespaceDone definition"}
-
-### MOQTPublishNamespaceCancel
-
-~~~ cddl
-MOQTPublishNamespaceCancel = {
-  type: "publish_namespace_cancel"
-  request_id: uint64
-  error_code: uint64
-  ? reason: text
-  ? reason_bytes: hexstring
-}
-~~~
-{: #publishnamespacecancel-def title="MOQTPublishNamespaceCancel definition"}
 
 ### MOQTSubscribeNamespace
 


### PR DESCRIPTION
The following control messages are obsolete in v17 of MOQT:
* MOQTUnsubscribe
* MOQTFetchCancel
* MOQTPublishNamespaceDone
* MOQTPublishNamespaceCancel