### PR TITLE
[updates for draft-17] Remove outdated parameters

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -627,15 +627,12 @@ $MOQTParameter /= {
 MOQTBaseParameters /= MOQTAuthorizationTokenParameter /
                       MOQTDeliveryTimeoutParameter /
                       MOQTRendezvousTimeoutParameter /
-                      MOQTMaxCacheDurationParameter /
-                      MOQTPublisherPriorityParameter /
                       MOQTSubscriberPriorityParameter /
                       MOQTGroupOrderParameter /
                       MOQTSubscriptionFilterParameter /
                       MOQTExpiresParameter /
                       MOQTLargestObjectParameter /
                       MOQTForwardParameter /
-                      MOQTDynamicGroupsParameter /
                       MOQTNewGroupRequestParameter /
                       MOQTUnknownParameter
 
@@ -675,26 +672,6 @@ MOQTRendezvousTimeoutParameter = {
 }
 ~~~
 {: #moqtrendezvoustimeoutparameter-def title="MOQTRendezvousTimeoutParameter definition"}
-
-### MOQTMaxCacheDurationParameter
-
-~~~ cddl
-MOQTMaxCacheDurationParameter = {
-  name: "max_cache_duration"
-  value: uint64
-}
-~~~
-{: #moqtmaxcachedurationparameter-def title="MOQTMaxCacheDurationParameter definition"}
-
-### MOQTPublisherPriorityParameter
-
-~~~ cddl
-MOQTPublisherPriorityParameter = {
-  name: "publisher_priority"
-  value: uint64
-}
-~~~
-{: #moqtpublisherpriorityparameter-def title="MOQTPublisherPriorityParameter definition"}
 
 ### MOQTSubscriberPriorityParameter
 
@@ -755,16 +732,6 @@ MOQTForwardParameter = {
 }
 ~~~
 {: #moqtforwardparameter-def title="MOQTForwardParameter definition"}
-
-### MOQTDynamicGroupsParameter
-
-~~~ cddl
-MOQTDynamicGroupsParameter = {
-  name: "dynamic_groups"
-  value: uint64
-}
-~~~
-{: #moqtdynamicgroupsparameter-def title="MOQTDynamicGroupsParameter definition"}
 
 ### MOQTNewGroupRequestParameter
 


### PR DESCRIPTION
max_cache_duration, default_publisher_priority, dynamic_groups are Properties, not message parameters in draft 17