### PR TITLE
[updates for draft-17] Rename "header" fields in MOQTProperty

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -1079,10 +1079,10 @@ MOQTPublishBlocked = {
 
 ~~~ cddl
 MOQTProperty = {
-  header_type: uint64
-  ? header_value: uint64
-  ? header_length: uint64
-  ? payload: RawInfo
+  type: uint64
+  ? value: uint64
+  ? length: uint64
+  ? value_bytes: RawInfo
 }
 ~~~
 {: #property-def title="Property definition"}


### PR DESCRIPTION
Properties used to be called extension headers. Since the name has changed, I'm removing the "header" portion from all of the fields of the MOQTProperty.