### PR TITLE
[updates for draft-18] Add optional request_id to MOQTGoaway

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -831,6 +831,7 @@ MOQTGoaway = {
   type: "goaway"
   new_session_uri: RawInfo
   timeout: uint64
+  ? request_id : uint64
 }
 ~~~
 {: #goaway-def title="MOQTGoaway definition"}


### PR DESCRIPTION
The request_id  is present when GOAWAY is sent on the control stream. It is absent when the GOAWAY is sent on an individual request stream.