### PR TITLE
[updates for draft-18] Remove request_id from MOQTRequestOk

### DIFF
--- a/draft-pardue-moq-qlog-moq-events.md
+++ b/draft-pardue-moq-qlog-moq-events.md
@@ -841,7 +841,6 @@ MOQTGoaway = {
 ~~~ cddl
 MOQTRequestOk = {
   type: "request_ok"
-  request_id: uint64
   number_of_parameters: uint64
   ? parameters: [* $MOQTParameter]
 }


### PR DESCRIPTION
Draft-18 correlates responses by their bidirectional request stream.